### PR TITLE
Fix depecation warning on build.

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@theia/application-package": "^0.3.12",
     "bunyan": "^1.8.10",
-    "circular-dependency-plugin": "^4.0.0",
+    "circular-dependency-plugin": "^5.0.0",
     "copy-webpack-plugin": "^4.5.0",
     "css-loader": "^0.28.1",
     "electron": "1.8.2-beta.5",


### PR DESCRIPTION
This change updates the major version of circular-dependency-plugin to resolve
    a reported deprecation warning that appears when build ing with webpack. Warning is
    ...'DeprecationWarning: Tapable.plugin is deprecated. Use new API on .hooks instead'
    See https://www.npmjs.com/package/circular-dependency-plugin for details.
    
    Signed-off-by: Mark Edgeworth <mark.edgeworth@arm.com>