### PR TITLE
IOTIDE-715 Workspace search does not work on Windows

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-service.ts
@@ -17,8 +17,8 @@
 import { injectable, inject, postConstruct } from "inversify";
 import { SearchInWorkspaceServer, SearchInWorkspaceClient, SearchInWorkspaceResult, SearchInWorkspaceOptions } from "../common/search-in-workspace-interface";
 import { WorkspaceService } from "@theia/workspace/lib/browser";
-import URI from "@theia/core/lib/common/uri";
 import { ILogger } from "@theia/core";
+import { FileUri } from "@theia/core/lib/node/file-uri";
 
 /**
  * Class that will receive the search results from the server.  This is separate
@@ -112,8 +112,7 @@ export class SearchInWorkspaceService implements SearchInWorkspaceClient {
             throw new Error("Search failed: no workspace root.");
         }
 
-        const rootUri = new URI(root.uri);
-        const searchId = await this.searchServer.search(what, rootUri.path.toString(), opts);
+        const searchId = await this.searchServer.search(what, FileUri.fsPath(root.uri), opts);
         this.pendingSearches.set(searchId, callbacks);
         this.lastKnownSearchId = searchId;
 


### PR DESCRIPTION
## Changes
- Fixes getting path to be file system specific

Fixes [IOTIDE-715](https://jira.arm.com/browse/IOTIDE-715) and [Theia issue 2039](https://github.com/theia-ide/theia/issues/2039).