### PR TITLE
Fork node processes instead of spawn

### DIFF
--- a/packages/process/src/node/raw-process.ts
+++ b/packages/process/src/node/raw-process.ts
@@ -18,7 +18,7 @@ import { injectable, inject, named } from 'inversify';
 import { ProcessManager } from './process-manager';
 import { ILogger } from '@theia/core/lib/common';
 import { Process, ProcessType, ProcessOptions } from './process';
-import { ChildProcess, spawn } from 'child_process';
+import { ChildProcess, spawn, fork } from 'child_process';
 import * as stream from 'stream';
 
 export const RawProcessOptions = Symbol('RawProcessOptions');
@@ -69,10 +69,19 @@ export class RawProcess extends Process {
            normalize the error handling by calling the error handler
            instead.  */
         try {
-            this.process = spawn(
-                options.command,
-                options.args,
-                options.options);
+            if (options.command === 'node' && options.args) {
+                this.process = fork(
+                    options.args[0],
+                    [],
+                    {
+                        'stdio': ['pipe', 'pipe', 2, 'ipc']
+                    });
+            } else {
+                this.process = spawn(
+                    options.command,
+                    options.args,
+                    options.options);
+            }
 
             this.process.on('error', this.emitOnError.bind(this));
             this.process.on('exit', this.emitOnExit.bind(this));


### PR DESCRIPTION
This PR reintroduces the fix I added for TechCon to fork the node process instead of spawn to allow debug to work in production.
