### PR TITLE
Fixed stack overflows on application start

### DIFF
--- a/packages/core/src/browser/label-provider.ts
+++ b/packages/core/src/browser/label-provider.ts
@@ -20,6 +20,7 @@ import URI from '../common/uri';
 import { ContributionProvider } from '../common/contribution-provider';
 import { Prioritizeable, MaybePromise } from '../common/types';
 import { Event, Emitter, Disposable, DisposableCollection } from '../common';
+import { FrontendApplicationContribution } from './frontend-application';
 
 export const FOLDER_ICON = 'fa fa-folder';
 export const FILE_ICON = 'fa fa-file';
@@ -92,7 +93,7 @@ export class DefaultUriLabelProviderContribution implements LabelProviderContrib
 }
 
 @injectable()
-export class LabelProvider implements Disposable {
+export class LabelProvider implements Disposable, FrontendApplicationContribution {
 
     private readonly toDispose: DisposableCollection = new DisposableCollection();
 
@@ -103,7 +104,9 @@ export class LabelProvider implements Disposable {
         protected readonly contributionProvider: ContributionProvider<LabelProviderContribution>
     ) {
         this.toDispose.push(this.onElementUpdatedEmitter);
+    }
 
+    public initialize(): void {
         const contributions = this.contributionProvider.getContributions();
         for (const contribution of contributions) {
             if (contribution.onElementUpdated) {


### PR DESCRIPTION
Calling `contributionProvider.getContributions` in the constructor was throwing errors because some of the contributions inject the LabelProvider. These errors could be observed by starting Mbed Studio and opening the developer console:

![range-errors](https://user-images.githubusercontent.com/12599255/64700601-1775de80-d49f-11e9-93a6-43b8113f5bd5.png)

This PR also seems to fix the emitter memory leak seen in the screenshot.

@westbury you may want to add this to your Theia PR.