### PR TITLE
Added option to only allow a single instance of the Electron app

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -128,172 +128,191 @@ const { fork } = require('child_process');
 const { app, shell, BrowserWindow, ipcMain, Menu } = electron;
 
 const applicationName = \`${this.pck.props.frontend.config.applicationName}\`;
+const wantSingleInstance = ${this.pck.props.backend.config.singleInstance === true ? 'true' : 'false'};
 
-const nativeKeymap = require('native-keymap');
-const Storage = require('electron-store');
-const electronStore = new Storage();
+if (wantSingleInstance && !app.requestSingleInstanceLock()) {
+    // There is another instance running, exit now. The other instance will request focus.
+    app.quit();
+} else {
+    const nativeKeymap = require('native-keymap');
+    const Storage = require('electron-store');
+    const electronStore = new Storage();
 
-app.on('ready', () => {
-    const { screen } = electron;
+    app.on('ready', () => {
+        const { screen } = electron;
 
-    // Remove the default electron menus, waiting for the application to set its own.
-    Menu.setApplicationMenu(Menu.buildFromTemplate([{
-        role: 'help', submenu: [{ role: 'toggledevtools'}]
-    }]));
+        // Remove the default electron menus, waiting for the application to set its own.
+        Menu.setApplicationMenu(Menu.buildFromTemplate([{
+            role: 'help', submenu: [{ role: 'toggledevtools'}]
+        }]));
 
-    function createNewWindow(theUrl) {
+        function createNewWindow(theUrl) {
 
-        // We must center by hand because \`browserWindow.center()\` fails on multi-screen setups
-        // See: https://github.com/electron/electron/issues/3490
-        const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
-        const height = Math.floor(bounds.height * (2/3));
-        const width = Math.floor(bounds.width * (2/3));
+            // We must center by hand because \`browserWindow.center()\` fails on multi-screen setups
+            // See: https://github.com/electron/electron/issues/3490
+            const { bounds } = screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
+            const height = Math.floor(bounds.height * (2/3));
+            const width = Math.floor(bounds.width * (2/3));
 
-        const y = Math.floor(bounds.y + (bounds.height - height) / 2);
-        const x = Math.floor(bounds.x + (bounds.width - width) / 2);
+            const y = Math.floor(bounds.y + (bounds.height - height) / 2);
+            const x = Math.floor(bounds.x + (bounds.width - width) / 2);
 
-        const WINDOW_STATE = 'windowstate';
-        const windowState = electronStore.get(WINDOW_STATE, {
-            width, height, x, y
-        });
+            const WINDOW_STATE = 'windowstate';
+            const windowState = electronStore.get(WINDOW_STATE, {
+                width, height, x, y
+            });
 
-        let windowOptions = {
-            show: false,
-            title: applicationName,
-            width: windowState.width,
-            height: windowState.height,
-            minWidth: 200,
-            minHeight: 120,
-            x: windowState.x,
-            y: windowState.y,
-            isMaximized: windowState.isMaximized
-        };
+            let windowOptions = {
+                show: false,
+                title: applicationName,
+                width: windowState.width,
+                height: windowState.height,
+                minWidth: 200,
+                minHeight: 120,
+                x: windowState.x,
+                y: windowState.y,
+                isMaximized: windowState.isMaximized
+            };
 
-        // Always hide the window, we will show the window when it is ready to be shown in any case.
-        const newWindow = new BrowserWindow(windowOptions);
-        if (windowOptions.isMaximized) {
-            newWindow.maximize();
+            // Always hide the window, we will show the window when it is ready to be shown in any case.
+            const newWindow = new BrowserWindow(windowOptions);
+            if (windowOptions.isMaximized) {
+                newWindow.maximize();
+            }
+            newWindow.on('ready-to-show', () => newWindow.show());
+
+            // Prevent calls to "window.open" from opening an ElectronBrowser window,
+            // and rather open in the OS default web browser.
+            newWindow.webContents.on('new-window', (event, url) => {
+                event.preventDefault();
+                shell.openExternal(url);
+            });
+
+            // Save the window geometry state on every change
+            const saveWindowState = () => {
+                try {
+                    let bounds;
+                    if (newWindow.isMaximized()) {
+                        bounds = electronStore.get(WINDOW_STATE, {});
+                    } else {
+                        bounds = newWindow.getBounds();
+                    }
+                    electronStore.set(WINDOW_STATE, {
+                        isMaximized: newWindow.isMaximized(),
+                        width: bounds.width,
+                        height: bounds.height,
+                        x: bounds.x,
+                        y: bounds.y
+                    });
+                } catch (e) {
+                    console.error("Error while saving window state.", e);
+                }
+            };
+            let delayedSaveTimeout;
+            const saveWindowStateDelayed = () => {
+                if (delayedSaveTimeout) {
+                    clearTimeout(delayedSaveTimeout);
+                }
+                delayedSaveTimeout = setTimeout(saveWindowState, 1000);
+            };
+            newWindow.on('close', saveWindowState);
+            newWindow.on('resize', saveWindowStateDelayed);
+            newWindow.on('move', saveWindowStateDelayed);
+
+            // Notify the renderer process on keyboard layout change
+            nativeKeymap.onDidChangeKeyboardLayout(() => {
+                if (!newWindow.isDestroyed()) {
+                    const newLayout = {
+                        info: nativeKeymap.getCurrentKeyboardLayout(),
+                        mapping: nativeKeymap.getKeyMap()
+                    };
+                    newWindow.webContents.send('keyboardLayoutChanged', newLayout);
+                }
+            });
+
+            if (!!theUrl) {
+                newWindow.loadURL(theUrl);
+            }
+            return newWindow;
         }
-        newWindow.on('ready-to-show', () => newWindow.show());
 
-        // Prevent calls to "window.open" from opening an ElectronBrowser window,
-        // and rather open in the OS default web browser.
-        newWindow.webContents.on('new-window', (event, url) => {
-            event.preventDefault();
+        app.on('window-all-closed', () => {
+            app.quit();
+        });
+        ipcMain.on('create-new-window', (event, url) => {
+            createNewWindow(url);
+        });
+        ipcMain.on('open-external', (event, url) => {
             shell.openExternal(url);
         });
 
-        // Save the window geometry state on every change
-        const saveWindowState = () => {
-            try {
-                let bounds;
-                if (newWindow.isMaximized()) {
-                    bounds = electronStore.get(WINDOW_STATE, {});
-                } else {
-                    bounds = newWindow.getBounds();
-                }
-                electronStore.set(WINDOW_STATE, {
-                    isMaximized: newWindow.isMaximized(),
-                    width: bounds.width,
-                    height: bounds.height,
-                    x: bounds.x,
-                    y: bounds.y
-                });
-            } catch (e) {
-                console.error("Error while saving window state.", e);
-            }
-        };
-        let delayedSaveTimeout;
-        const saveWindowStateDelayed = () => {
-            if (delayedSaveTimeout) {
-                clearTimeout(delayedSaveTimeout);
-            }
-            delayedSaveTimeout = setTimeout(saveWindowState, 1000);
-        };
-        newWindow.on('close', saveWindowState);
-        newWindow.on('resize', saveWindowStateDelayed);
-        newWindow.on('move', saveWindowStateDelayed);
-
-        // Notify the renderer process on keyboard layout change
-        nativeKeymap.onDidChangeKeyboardLayout(() => {
-            if (!newWindow.isDestroyed()) {
-                const newLayout = {
-                    info: nativeKeymap.getCurrentKeyboardLayout(),
-                    mapping: nativeKeymap.getKeyMap()
-                };
-                newWindow.webContents.send('keyboardLayoutChanged', newLayout);
-            }
-        });
-
-        if (!!theUrl) {
-            newWindow.loadURL(theUrl);
-        }
-        return newWindow;
-    }
-
-    app.on('window-all-closed', () => {
-        app.quit();
-    });
-    ipcMain.on('create-new-window', (event, url) => {
-        createNewWindow(url);
-    });
-    ipcMain.on('open-external', (event, url) => {
-        shell.openExternal(url);
-    });
-
-    // Check whether we are in bundled application or development mode.
-    // @ts-ignore
-    const devMode = process.defaultApp || /node_modules[\/]electron[\/]/.test(process.execPath);
-    const mainWindow = createNewWindow();
-    const loadMainWindow = (port) => {
-        if (!mainWindow.isDestroyed()) {
-            mainWindow.loadURL('file://' + join(__dirname, '../../lib/index.html') + '?port=' + port);
-        }
-    };
-
-    // We cannot use the \`process.cwd()\` as the application project path (the location of the \`package.json\` in other words)
-    // in a bundled electron application because it depends on the way we start it. For instance, on OS X, these are a differences:
-    // https://github.com/theia-ide/theia/issues/3297#issuecomment-439172274
-    process.env.THEIA_APP_PROJECT_PATH = resolve(__dirname, '..', '..');
-
-    // Set the electron version for both the dev and the production mode. (https://github.com/theia-ide/theia/issues/3254)
-    // Otherwise, the forked backend processes will not know that they're serving the electron frontend.
-    const { versions } = process;
-    // @ts-ignore
-    if (versions && typeof versions.electron !== 'undefined') {
+        // Check whether we are in bundled application or development mode.
         // @ts-ignore
-        process.env.THEIA_ELECTRON_VERSION = versions.electron;
-    }
+        const devMode = process.defaultApp || /node_modules[/]electron[/]/.test(process.execPath);
+        const mainWindow = createNewWindow();
 
-    const mainPath = join(__dirname, '..', 'backend', 'main');
-    // We need to distinguish between bundled application and development mode when starting the clusters.
-    // See: https://github.com/electron/electron/issues/6337#issuecomment-230183287
-    if (devMode) {
-        require(mainPath).then(address => {
-            loadMainWindow(address.port);
-        }).catch((error) => {
-            console.error(error);
-            app.exit(1);
-        });
-    } else {
-        const cp = fork(mainPath, [], { env: Object.assign({}, process.env) });
-        cp.on('message', (message) => {
-            loadMainWindow(message);
-        });
-        cp.on('error', (error) => {
-            console.error(error);
-            app.exit(1);
-        });
-        app.on('quit', () => {
-            // If we forked the process for the clusters, we need to manually terminate it.
-            // See: https://github.com/theia-ide/theia/issues/835
-            process.kill(cp.pid);
-        });
+        if (wantSingleInstance) {
+            app.on('second-instance', (event, commandLine, workingDirectory) => {
+                // Someone tried to run a second instance, we should focus our window.
+                if (mainWindow && !mainWindow.isDestroyed()) {
+                    if (mainWindow.isMinimized()) {
+                        mainWindow.restore();
+                    }
+                    mainWindow.focus()
+                }
+            })
+        }
+
+        const loadMainWindow = (port) => {
+            if (!mainWindow.isDestroyed()) {
+                mainWindow.loadURL('file://' + join(__dirname, '../../lib/index.html') + '?port=' + port);
+            }
+        };
+
+        // We cannot use the \`process.cwd()\` as the application project path (the location of the \`package.json\` in other words)
+        // in a bundled electron application because it depends on the way we start it. For instance, on OS X, these are a differences:
+        // https://github.com/theia-ide/theia/issues/3297#issuecomment-439172274
+        process.env.THEIA_APP_PROJECT_PATH = resolve(__dirname, '..', '..');
+
+        // Set the electron version for both the dev and the production mode. (https://github.com/theia-ide/theia/issues/3254)
+        // Otherwise, the forked backend processes will not know that they're serving the electron frontend.
+        const { versions } = process;
+        // @ts-ignore
+        if (versions && typeof versions.electron !== 'undefined') {
+            // @ts-ignore
+            process.env.THEIA_ELECTRON_VERSION = versions.electron;
+        }
+
+        const mainPath = join(__dirname, '..', 'backend', 'main');
+        // We need to distinguish between bundled application and development mode when starting the clusters.
+        // See: https://github.com/electron/electron/issues/6337#issuecomment-230183287
+        if (devMode) {
+            require(mainPath).then(address => {
+                loadMainWindow(address.port);
+            }).catch((error) => {
+                console.error(error);
+                app.exit(1);
+            });
+        } else {
+            const cp = fork(mainPath, [], { env: Object.assign({}, process.env) });
+            cp.on('message', (message) => {
+                loadMainWindow(message);
+            });
+            cp.on('error', (error) => {
+                console.error(error);
+                app.exit(1);
+            });
+            app.on('quit', () => {
+                // If we forked the process for the clusters, we need to manually terminate it.
+                // See: https://github.com/theia-ide/theia/issues/835
+                process.kill(cp.pid);
+            });
         }${
             this.pck.backendElectronMasterModules.size > 0 ?
-                `
+            `
         require('../backend/electron-master.js');` : ''}
-});
+    });
+}
 `;
     }
 

--- a/dev-packages/application-package/src/application-props.ts
+++ b/dev-packages/application-package/src/application-props.ts
@@ -116,6 +116,11 @@ export interface FrontendApplicationConfig extends ApplicationConfig {
  */
 export interface BackendApplicationConfig extends ApplicationConfig {
 
+    /**
+     * If true and in Electron mode, only one instance of the application is allowed to run at a time.
+     */
+    singleInstance?: boolean;
+
 }
 
 /**


### PR DESCRIPTION
Added an option to the backend config: `singleInstance`. If true and in Electron mode, only one instance of the application is allowed to run at a time. If a second is started, it terminates itself and the original instance's window is focused.

See: https://electronjs.org/docs/api/app#apprequestsingleinstancelock.