### PR TITLE
WorkingDirectoryStatus should include currentHead

### DIFF
--- a/packages/hg/src/node/hg-impl.ts
+++ b/packages/hg/src/node/hg-impl.ts
@@ -196,6 +196,7 @@ export class HgImpl implements Hg {
             changes,
             exists: true,
             branch: branch ? branch.name : undefined,
+            currentHead: branch ? branch.tip.sha : undefined,
         };
     }
 


### PR DESCRIPTION
#### What it does
When pulling to update a remote Mercurial repository the UI does not update with the latest commit history because `HgRepositoryWatcher` does not detect the change and then does not rise the `onStatusChanged` event.

Added the tip hash to the `WorkingDirectoryStatus`, it causes `HgRepositoryWatcher` to detect the change and fire the appropriate event which will _bubble_ up to the UI that will then be refreshed.

#### How to test
- Create a Mercurial repo.
- Clone the repo locally.
- Create a second clone in a separate location, change something and publish the changes.
- Back in the first repo: pull the remote changes.

Before the fix: source code will be updated but the _head_ widget and the source history aren't updated until IDE is restarted. 
After the fix: the new history is visible.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

