### PR TITLE
Disable amend support for Mercurial SCM

### DIFF
--- a/packages/hg/src/browser/hg-scm-provider.ts
+++ b/packages/hg/src/browser/hg-scm-provider.ts
@@ -1,4 +1,4 @@
- /********************************************************************************
+/********************************************************************************
  * Copyright (C) 2019 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the

--- a/packages/hg/src/browser/hg-scm-provider.ts
+++ b/packages/hg/src/browser/hg-scm-provider.ts
@@ -1,4 +1,4 @@
-/********************************************************************************
+ /********************************************************************************
  * Copyright (C) 2019 TypeFox and others.
  *
  * This program and the accompanying materials are made available under the
@@ -90,7 +90,8 @@ export class HgScmProvider implements ScmProvider {
 
     @postConstruct()
     protected init(): void {
-        this._amendSupport = new HgAmendSupport(this, this.repository, this.hg);
+        // Amend is temporarily disabled for Mercurial.
+        // this._amendSupport = new HgAmendSupport(this, this.repository, this.hg);
     }
 
     get repository(): Repository {
@@ -100,8 +101,8 @@ export class HgScmProvider implements ScmProvider {
         return this.repository.localUri;
     }
 
-    protected _amendSupport: HgAmendSupport;
-    get amendSupport(): HgAmendSupport {
+    protected _amendSupport?: HgAmendSupport;
+    get amendSupport(): HgAmendSupport | undefined {
         return this._amendSupport;
     }
 

--- a/packages/scm/src/browser/scm-amend-component.tsx
+++ b/packages/scm/src/browser/scm-amend-component.tsx
@@ -340,18 +340,13 @@ export class ScmAmendComponent extends React.Component<ScmAmendComponentProps, S
             return '';
         }
 
-        const canAmend: boolean = true;
         return <div className={ScmAmendComponent.Styles.COMMIT_AND_BUTTON} style={{ flexGrow: 0, flexShrink: 0 }} key={this.state.lastCommit.commit.id}>
             {this.renderLastCommitNoButton(this.state.lastCommit)}
-            {
-                canAmend
-                    ? <div className={ScmAmendComponent.Styles.FLEX_CENTER}>
-                        <button className='theia-button' title='Amend last commit' onClick={this.amend}>
-                            Amend
-                        </button>
-                    </div>
-                    : ''
-            }
+            <div className={ScmAmendComponent.Styles.FLEX_CENTER}>
+                <button className='theia-button' title='Amend last commit' onClick={this.amend}>
+                    Amend
+                </button>
+            </div>
         </div>;
     }
 


### PR DESCRIPTION
#### What it does
Amend support does not work in many edge-cases, this disables amend for Hg leaving the code in-place inside `HgScmProvider` to be re-enabled when everything will be fixed.

#### How to test
Open a project from a Mercurial repo, the _Amend_ button (and its container control with the head info) in the _Source Control_ pane should be hidden. Head info is still available in the _Source History_ pane.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

