### PR TITLE
IOTIDE 2157: hg forget operation replaced with discard

### DIFF
--- a/packages/hg/src/browser/hg-contribution.ts
+++ b/packages/hg/src/browser/hg-contribution.ts
@@ -187,14 +187,19 @@ export class HgContribution implements CommandContribution, MenuContribution, Ta
             commandId: HG_COMMANDS.TRACK.id,
             when: 'scmProvider == hg && scmResourceGroup == untracked'
         });
+        registerResourceAction('1_modification', {
+            commandId: HG_COMMANDS.DISCARD.id,
+            when: 'scmProvider == hg && scmResourceGroup == changed'
+        });
 
         registerResourceAction('navigation', {
             commandId: HG_COMMANDS.OPEN_CHANGED_FILE.id,
             when: 'scmProvider == hg && scmResourceGroup == changed'
         });
+        // currently not shown
         registerResourceAction('1_modification', {
             commandId: HG_COMMANDS.UNTRACK.id,
-            when: 'scmProvider == hg && scmResourceGroup == changed'
+            when: 'scmProvider == hg && false'
         });
 
         registerResourceAction('navigation', {

--- a/packages/hg/src/node/hg-impl.ts
+++ b/packages/hg/src/node/hg-impl.ts
@@ -219,8 +219,11 @@ export class HgImpl implements Hg {
     }
 
     async forget(repository: Repository, uris: string[]): Promise<void> {
-        const paths = uris.map(uri => FileUri.fsPath(uri));
-        await this.runCommand(repository, ['forget', ...paths]);
+        const op = async () => {
+            const paths = uris.map(uri => FileUri.fsPath(uri));
+            await this.runCommand(repository, ['forget', ...paths]);
+        };
+        return this.manager.run(repository, () => op());
     }
 
     async branches(repository: Repository): Promise<Branch[]> {

--- a/packages/hg/src/node/hg-impl.ts
+++ b/packages/hg/src/node/hg-impl.ts
@@ -665,6 +665,7 @@ export class HgImpl implements Hg {
      */
     async revert(repository: Repository, options: Hg.Options.Revert): Promise<void> {
         const args = ['revert'];
+        args.push('--no-backup');
         if (options.revision) {
             args.push('-r');
             args.push(options.revision);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

[hg forget operation replaced with discard](https://jira.arm.com/browse/IOTIDE-2157)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Edit a tracked file. Instead of the `forget` operation, `discard` is shown.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- [ ] as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

