### PR TITLE
Implemented Hg.createBranch() and removed Hg.checkout() after hg.createBranch() call.

### DIFF
--- a/packages/hg/src/browser/hg-quick-open-service.ts
+++ b/packages/hg/src/browser/hg-quick-open-service.ts
@@ -269,7 +269,6 @@ export class HgQuickOpenService {
                                 async () => {
                                     try {
                                         await hgQuickOpenService.hg.createBranch(repository, lookFor);
-                                        await hgQuickOpenService.hg.checkout(repository, { branch: lookFor });
                                     } catch (error) {
                                         hgQuickOpenService.hgErrorHandler.handleError(error);
                                     }

--- a/packages/hg/src/common/hg.ts
+++ b/packages/hg/src/common/hg.ts
@@ -631,10 +631,8 @@ export interface Hg extends Disposable {
      *
      * @param the repository where the branch modification has to be performed.
      * @param branchName The desired name of the new branch.
-     * @param branchStartPoint The new branch head will point to this commit. It may be given as a branch name, a commit-id, or a tag.
-     * If this parameter is omitted, the current `HEAD` will be used instead.
      */
-    createBranch(repository: Repository, branchName: string, branchStartPoint?: string): Promise<void>
+    createBranch(repository: Repository, branchName: string): Promise<void>
 
     /**
      * Switches branches or restores working tree files.

--- a/packages/hg/src/node/hg-impl.ts
+++ b/packages/hg/src/node/hg-impl.ts
@@ -270,8 +270,8 @@ export class HgImpl implements Hg {
 
     }
 
-    async createBranch(repository: Repository, branchName: string, branchStartPoint?: string): Promise<void> {
-        throw Error('not implemented yet');
+    async createBranch(repository: Repository, branchName: string): Promise<void> {
+        await this.runCommand(repository, ['branch', branchName]);
     }
 
     async checkout(repository: Repository, options: Hg.Options.Checkout.CheckoutBranch | Hg.Options.Checkout.WorkingTreeFile): Promise<void> {


### PR DESCRIPTION
#### What it does
* Implemented `Hg.createBranch()` (command `hg branch`).
* Removed the call to `Hg.checkout()` after `Hg.createBranch()`, the newly created branch is already active (and anyway `checkout` needs a `commit` before selecting a new branch from remote).

Note: It uses `hg branch <name>` without `-f` then the branch name must be unique.

#### How to test
* Click the branch name in the status bar.
* Click _Create new branch_.
* Type the name of a new (non existing) branch.
* Confirm with Enter.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

