### PR TITLE
Added CommandService.onDidExecuteCommand event

### DIFF
--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -152,8 +152,6 @@ export interface CommandService {
 
     /**
      * An event is emmited when a command is about to be executed.
-     *
-     * It can be used to install or activate a command handler.
      */
     readonly onDidExecuteCommand: Event<DidExecuteCommandEvent>;
 }

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -287,7 +287,7 @@ export class CommandRegistry implements CommandService {
      */
     // tslint:disable-next-line:no-any
     async executeCommand<T>(commandId: string, ...args: any[]): Promise<T | undefined> {
-        const executionId = `${commandId}--${this.executionId++}`;
+        const executionId = `${commandId}:${this.executionId++}`;
         await this.fireWillExecuteCommand(commandId, executionId, args);
         const handler = this.getActiveHandler(commandId, ...args);
         if (handler) {

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -151,7 +151,7 @@ export interface CommandService {
     readonly onWillExecuteCommand: Event<WillExecuteCommandEvent>;
 
     /**
-     * An event is emmited when a command has been successfully to be executed.
+     * An event is emmited when a command has been successfully executed.
      */
     readonly onDidExecuteCommand: Event<DidExecuteCommandEvent>;
 }

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -119,12 +119,14 @@ export interface CommandContribution {
 }
 
 export interface WillExecuteCommandEvent extends WaitUntilEvent {
+    timestamp: number;
     commandId: string;
     // tslint:disable-next-line:no-any
     args: any[];
 }
 
 export interface DidExecuteCommandEvent extends WaitUntilEvent {
+    timestamp: number;
     commandId: string;
     // tslint:disable-next-line:no-any
     args: any[];
@@ -285,11 +287,12 @@ export class CommandRegistry implements CommandService {
      */
     // tslint:disable-next-line:no-any
     async executeCommand<T>(commandId: string, ...args: any[]): Promise<T | undefined> {
-        await this.fireWillExecuteCommand(commandId, args);
+        const timestamp = Date.now();
+        await this.fireWillExecuteCommand(commandId, timestamp, args);
         const handler = this.getActiveHandler(commandId, ...args);
         if (handler) {
             const result = await handler.execute(...args);
-            await this.fireDidExecuteCommand(commandId, args);
+            await this.fireDidExecuteCommand(commandId, timestamp, args);
             const command = this.getCommand(commandId);
             if (command) {
                 this.addRecentCommand(command);
@@ -301,13 +304,13 @@ export class CommandRegistry implements CommandService {
     }
 
     // tslint:disable-next-line:no-any
-    protected async fireWillExecuteCommand(commandId: string, args: any[]): Promise<void> {
-        await WaitUntilEvent.fire(this.onWillExecuteCommandEmitter, { commandId, args }, 30000);
+    protected async fireWillExecuteCommand(commandId: string, timestamp: number, args: any[]): Promise<void> {
+        await WaitUntilEvent.fire(this.onWillExecuteCommandEmitter, { commandId, timestamp, args }, 30000);
     }
 
     // tslint:disable-next-line:no-any
-    protected async fireDidExecuteCommand(commandId: string, args: any[]): Promise<void> {
-        await WaitUntilEvent.fire(this.onDidExecuteCommandEmitter, { commandId, args }, 30000);
+    protected async fireDidExecuteCommand(commandId: string, timestamp: number, args: any[]): Promise<void> {
+        await WaitUntilEvent.fire(this.onDidExecuteCommandEmitter, { commandId, timestamp, args }, 30000);
     }
 
     /**

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -120,11 +120,13 @@ export interface CommandContribution {
 
 export interface WillExecuteCommandEvent extends WaitUntilEvent {
     commandId: string;
+    // tslint:disable-next-line:no-any
     args: any[];
 }
 
 export interface DidExecuteCommandEvent extends WaitUntilEvent {
     commandId: string;
+    // tslint:disable-next-line:no-any
     args: any[];
 }
 
@@ -300,10 +302,12 @@ export class CommandRegistry implements CommandService {
         throw new Error(`The command '${commandId}' cannot be executed. There are no active handlers available for the command.${argsMessage}`);
     }
 
+    // tslint:disable-next-line:no-any
     protected async fireWillExecuteCommand(commandId: string, args: any[]): Promise<void> {
         await WaitUntilEvent.fire(this.onWillExecuteCommandEmitter, { commandId, args }, 30000);
     }
 
+    // tslint:disable-next-line:no-any
     protected async fireDidExecuteCommand(commandId: string, args: any[]): Promise<void> {
         await WaitUntilEvent.fire(this.onDidExecuteCommandEmitter, { commandId, args }, 30000);
     }

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -151,7 +151,7 @@ export interface CommandService {
     readonly onWillExecuteCommand: Event<WillExecuteCommandEvent>;
 
     /**
-     * An event is emmited when a command is about to be executed.
+     * An event is emmited when a command has been successfully to be executed.
      */
     readonly onDidExecuteCommand: Event<DidExecuteCommandEvent>;
 }

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -163,7 +163,7 @@ export interface CommandService {
  */
 @injectable()
 export class CommandRegistry implements CommandService {
-
+    private executionId = 0;
     protected readonly _commands: { [id: string]: Command } = {};
     protected readonly _handlers: { [id: string]: CommandHandler[] } = {};
 
@@ -287,7 +287,7 @@ export class CommandRegistry implements CommandService {
      */
     // tslint:disable-next-line:no-any
     async executeCommand<T>(commandId: string, ...args: any[]): Promise<T | undefined> {
-        const executionId = Date.now().toString();
+        const executionId = `${commandId}--${this.executionId++}`;
         await this.fireWillExecuteCommand(commandId, executionId, args);
         const handler = this.getActiveHandler(commandId, ...args);
         if (handler) {

--- a/packages/core/src/common/command.ts
+++ b/packages/core/src/common/command.ts
@@ -119,14 +119,14 @@ export interface CommandContribution {
 }
 
 export interface WillExecuteCommandEvent extends WaitUntilEvent {
-    timestamp: number;
+    executionId: string;
     commandId: string;
     // tslint:disable-next-line:no-any
     args: any[];
 }
 
 export interface DidExecuteCommandEvent extends WaitUntilEvent {
-    timestamp: number;
+    executionId: string;
     commandId: string;
     // tslint:disable-next-line:no-any
     args: any[];
@@ -287,12 +287,12 @@ export class CommandRegistry implements CommandService {
      */
     // tslint:disable-next-line:no-any
     async executeCommand<T>(commandId: string, ...args: any[]): Promise<T | undefined> {
-        const timestamp = Date.now();
-        await this.fireWillExecuteCommand(commandId, timestamp, args);
+        const executionId = Date.now().toString();
+        await this.fireWillExecuteCommand(commandId, executionId, args);
         const handler = this.getActiveHandler(commandId, ...args);
         if (handler) {
             const result = await handler.execute(...args);
-            await this.fireDidExecuteCommand(commandId, timestamp, args);
+            await this.fireDidExecuteCommand(commandId, executionId, args);
             const command = this.getCommand(commandId);
             if (command) {
                 this.addRecentCommand(command);
@@ -304,13 +304,13 @@ export class CommandRegistry implements CommandService {
     }
 
     // tslint:disable-next-line:no-any
-    protected async fireWillExecuteCommand(commandId: string, timestamp: number, args: any[]): Promise<void> {
-        await WaitUntilEvent.fire(this.onWillExecuteCommandEmitter, { commandId, timestamp, args }, 30000);
+    protected async fireWillExecuteCommand(commandId: string, executionId: string, args: any[]): Promise<void> {
+        await WaitUntilEvent.fire(this.onWillExecuteCommandEmitter, { commandId, executionId, args }, 30000);
     }
 
     // tslint:disable-next-line:no-any
-    protected async fireDidExecuteCommand(commandId: string, timestamp: number, args: any[]): Promise<void> {
-        await WaitUntilEvent.fire(this.onDidExecuteCommandEmitter, { commandId, timestamp, args }, 30000);
+    protected async fireDidExecuteCommand(commandId: string, executionId: string, args: any[]): Promise<void> {
+        await WaitUntilEvent.fire(this.onDidExecuteCommandEmitter, { commandId, executionId, args }, 30000);
     }
 
     /**


### PR DESCRIPTION
#### What it does
* Added a new `CommandService.onDidExecuteCommand` event. It is complimentary to `CommandService.onWillExecuteCommand` and it is fired after a command has been successfully executed.
* Added `WillCommandExecute.args` property: when handling the event it might be useful to also know with which argument the command will be invoked.
* Added `WillCommandExecute.executionId`, similar to `progressId` for the progress events: you can use to to keep track of the command you are observing (`DidCommandExecute.executionId` and `WillCommandExecute.progressId` match for each specific _execution_ of a command).

#### How to test
In any handler for the `CommandService.onWillExecuteCommand` check that the `args` property of the event arguments contains the actual parameters for the command to execute.
Add an handler for `CommandService.onDidExecuteCommand` and try to execute a command (such as `FILE_DELETE`): the event should be raised after the command successfully completed.

#### Review checklist
- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

