### PR TITLE
Fix notifications timeout

### DIFF
--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -202,7 +202,7 @@ export class NotificationManager extends MessageClient {
         }
     }
     protected getTimeout(plainMessage: PlainMessage): number {
-        if (plainMessage.actions && !plainMessage.actions.length) {
+        if (plainMessage.actions && plainMessage.actions.length) {
             return 0;
         }
         return plainMessage.options && plainMessage.options.timeout || this.preferences['notification.timeout'];


### PR DESCRIPTION
Notification should be indefinite only when there is at least one action. Otherwise, it should respect a timeout.

@thegecko @mcgordonite what do you think about it? Isn't it better to remove the whole if and always respect the timeout set.


