### PR TITLE
Make head label in scm-history panel dynamically sized.

### DIFF
--- a/packages/scm-extra/src/browser/style/history.css
+++ b/packages/scm-extra/src/browser/style/history.css
@@ -49,7 +49,6 @@
     display: flex;
     width: 100%;
     box-sizing: border-box;
-    padding: 0 8px 0 2px;
 }
 
 .theia-scm-history .commitListElement .containerHead .headContent .image-container{
@@ -61,7 +60,8 @@
 }
 
 .theia-scm-history .commitListElement .containerHead .headContent .headLabelContainer{
-    min-width: calc(100% - 93px);
+    flex-grow: 1;
+    min-width: 0;
 }
 
 .theia-scm-history .commitListElement .containerHead .headContent .headLabelContainer.singleFileMode{


### PR DESCRIPTION
I would like to upstream this CSS fix to Theia, but first making PR here so the team can see it and share any opinions.

The problem: The `.theia-scm-history` panel's spacing is broken in Mbed Studio as we are using slightly different sized icons from vanilla Theia (Font Awesome Pro vs Font Awesome Free).

The fix: Do not calculate the width with some arbitrary pixel value, but use `flex-grow: 1` instead to grow the head label. This allows different font and icon sizes without breaking the spacing of the container elements. `min-width: 0` is required as `min-width` defaults to `auto` for flex elements, which prevents minimizing of the head label if not set.

I have checked that this works in both the Theia examples and Mbed Studio. 

Before fix (note change count on right poking over edge):
<img width="261" alt="Screenshot 2020-10-01 at 16 58 36" src="https://user-images.githubusercontent.com/11059840/94833746-658db500-0407-11eb-92ad-411d77ffc34d.png">

After Fix:
<img width="262" alt="Screenshot 2020-10-01 at 16 57 18" src="https://user-images.githubusercontent.com/11059840/94833755-69213c00-0407-11eb-93d0-fa357346a04c.png">
