### PR TITLE
Fix macOS update

### DIFF
--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -380,12 +380,16 @@ app.on('ready', () => {
         // We want to pass flags passed to the Electron app to the backend process.
         // Quirk: When developing from sources, we execute Electron as \`electron.exe electron-main.js ...args\`, but when bundled,
         // the command looks like \`bundled-application.exe ...args\`.
-        const cp = fork(mainPath, process.argv.slice(devMode ? 2 : 1), { env: Object.assign({
+        const cp = fork(mainPath, [], { env: Object.assign({
             [ElectronSecurityToken]: JSON.stringify(electronSecurityToken),
         }, process.env) });
         cp.on('message', async (address) => {
-            await setElectronSecurityToken(address.port);
-            loadMainWindow(address.port);
+            let messagePort = address.port;
+            if (!messagePort) {
+                messagePort = address;
+            }
+            await setElectronSecurityToken(messagePort);
+            loadMainWindow(messagePort);
         });
         cp.on('error', (error) => {
             console.error(error);


### PR DESCRIPTION
Fix for https://jira.arm.com/browse/IOTIDE-3152. This change fixes the auto-update not working on macOS.
How to test:
platform: macOS
1) Download official 1.2.1 release https://studio.mbed.com/installers/latest/mac/MbedStudio.pkg
2) Update `/Applications/Mbed Studio.app/Contents/Resources/app-update.yml` to:
```
bucket: `mbed-studio-private`
path: `installers/test/mac`
```
The path above is where I uploaded a Studio built with Theia version that uses code from this PR
3) Check that auto-update is triggered and make sure to select `update now`
4) Studio should start correctly
