### PR TITLE
Override vscode api version

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -19,7 +19,7 @@
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 
-export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
+export const VSCODE_DEFAULT_API_VERSION = '1.46.0';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -789,7 +789,7 @@ export function createAPIFactory(
         };
 
         return <typeof theia>{
-            version: require('../../package.json').version,
+            version: process.env['VSCODE_API_VERSION'] || require('../../package.json').version,
             commands,
             comment,
             window,


### PR DESCRIPTION
Update VSCode API version to 1.46.0. Master of Theia is using version 1.50.0 at the moment. It is required as vscode plugins like `vscode-clangd` have a minimal vecode version that they require: https://github.com/clangd/vscode-clangd/blob/master/package.json#L11  
