### PR TITLE
Refresh widgets tracked by debug widget on show

### DIFF
--- a/packages/debug/src/browser/view/debug-session-widget.ts
+++ b/packages/debug/src/browser/view/debug-session-widget.ts
@@ -109,6 +109,11 @@ export class DebugSessionWidget extends BaseWidget implements StatefulWidget, Ap
         this.toolbar.focus();
     }
 
+    protected onAfterShow(msg: Message): void {
+        super.onAfterShow(msg);
+        this.getTrackableWidgets().forEach(w => w.update());
+    }
+
     getTrackableWidgets(): Widget[] {
         return this.viewContainer.getTrackableWidgets();
     }


### PR DESCRIPTION
Debug details cleared when a debug session is interrupted.

See https://github.com/eclipse-theia/theia/pull/8645 .

Necessary to properly fix https://jira.arm.com/browse/IOTIDE-3113 .