### PR TITLE
Update VS Code API to version 1.46.0

### DIFF
--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -19,7 +19,7 @@
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 
-export const VSCODE_DEFAULT_API_VERSION = '1.46.0';
+export const VSCODE_DEFAULT_API_VERSION = '1.52.0';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts
@@ -19,7 +19,7 @@
 import * as theia from '@theia/plugin';
 import { BackendInitializationFn, PluginAPIFactory, Plugin, emptyPlugin } from '@theia/plugin-ext';
 
-export const VSCODE_DEFAULT_API_VERSION = '1.44.0';
+export const VSCODE_DEFAULT_API_VERSION = '1.46.0';
 
 /** Set up en as a default locale for VS Code extensions using vscode-nls */
 process.env['VSCODE_NLS_CONFIG'] = JSON.stringify({ locale: 'en', availableLanguages: {} });

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -789,7 +789,7 @@ export function createAPIFactory(
         };
 
         return <typeof theia>{
-            version: require('../../package.json').version,
+            version: process.env['VSCODE_API_VERSION'] || require('../../package.json').version,
             commands,
             comment,
             window,


### PR DESCRIPTION
Update VSCode version to version 1.46.0. It is needed for `vscode-clangd` plugin to work. We do not need to upstream it to Theia as the current master already has a newer version (1.50.0). I've updated to a minimal version that is needed for vscode-clangd to work.

