### PR TITLE
Render indicator next to node contents

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -51,6 +51,13 @@
     cursor: pointer;
 }
 
+.theia-TreeNodeIndicator {
+    position: absolute;
+    width: var(--theia-ui-padding);
+    height: 100%;
+    background-color: transparent;
+}
+
 .theia-TreeNodeContent {
     display: flex;
     align-items: center;

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -44,6 +44,7 @@ const debounce = require('lodash.debounce');
 export const TREE_CLASS = 'theia-Tree';
 export const TREE_CONTAINER_CLASS = 'theia-TreeContainer';
 export const TREE_NODE_CLASS = 'theia-TreeNode';
+export const TREE_NODE_INDICATOR_CLASS = 'theia-TreeNodeIndicator';
 export const TREE_NODE_CONTENT_CLASS = 'theia-TreeNodeContent';
 export const TREE_NODE_TAIL_CLASS = 'theia-TreeNodeTail';
 export const TREE_NODE_SEGMENT_CLASS = 'theia-TreeNodeSegment';
@@ -482,6 +483,25 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     }
 
     /**
+     * Render the tree node indicator given the node properties.
+     * @param node the tree node.
+     * @param props the node properties.
+     */
+    protected renderIndicator(node: TreeNode, props: NodeProps): React.ReactNode {
+        let style: React.CSSProperties = {
+        };
+        const indicatorColor = this.getDecorationData(node, 'indicatorColor').filter(notEmpty).shift();
+        if (indicatorColor) {
+            style = {
+                ...style,
+                backgroundColor: indicatorColor
+            };
+        }
+        return <div className={TREE_NODE_INDICATOR_CLASS} style={style}>
+        </div>;
+    }
+
+    /**
      * Render the tree node given the node properties.
      * @param node the tree node.
      * @param props the node properties.
@@ -786,6 +806,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             return undefined;
         }
         const attributes = this.createNodeAttributes(node, props);
+        const indicator = this.renderIndicator(node, props);
         const content = <div className={TREE_NODE_CONTENT_CLASS}>
             {this.renderExpansionToggle(node, props)}
             {this.decorateIcon(node, this.renderIcon(node, props))}
@@ -794,7 +815,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             {this.renderCaptionAffixes(node, props, 'captionSuffixes')}
             {this.renderTailDecorations(node, props)}
         </div>;
-        return React.createElement('div', attributes, content);
+        return React.createElement('div', attributes, indicator, content);
     }
 
     /**

--- a/packages/core/src/browser/widget-decoration.ts
+++ b/packages/core/src/browser/widget-decoration.ts
@@ -303,6 +303,10 @@ export namespace WidgetDecoration {
          */
         readonly backgroundColor?: Color;
         /**
+         * The background color of the indicator.
+         */
+        readonly indicatorColor?: Color;
+        /**
          * Optional, leading prefixes right before the caption.
          */
         readonly captionPrefixes?: CaptionAffix[];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-theia/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Render a transparent indicator next to the contents of every tree node.

This is needed for [ticket 3377](https://jira.arm.com/browse/IOTIDE-3377), where colour can be applied depending on different behaviours/features such as the active program.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
When viewed with DevTools, a `<div class="theia-TreeNodeIndicator">` should be present within the same parent of every `<div class="theia-TreeNodeContent">` .

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to review in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)