### PR TITLE
[Debug] Fixed issue on readonly variables

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -232,6 +232,9 @@ export class DebugVariable extends ExpressionContainer {
     protected setNameRef = (nameRef: HTMLSpanElement | null) => this.nameRef = nameRef || undefined;
 
     async open(): Promise<void> {
+        if (!this.supportSetVariable) {
+            return;
+        }
         const input = new SingleTextInputDialog({
             title: `Set ${this.name} Value`,
             initialValue: this.value


### PR DESCRIPTION
Variables are made not editable if the debug session doesn't support writing variables.

[Change already approved in the Theia repo](https://github.com/eclipse-theia/theia/pull/9616#event-4947337306).